### PR TITLE
Add extending path with bin directory of poetry

### DIFF
--- a/lua/poetry-nvim/init.lua
+++ b/lua/poetry-nvim/init.lua
@@ -4,7 +4,9 @@ local checkForLockfile = function()
   local match = vim.fn.glob(vim.fn.getcwd() .. "/poetry.lock")
   if match ~= "" then
     local poetry_venv = vim.fn.trim(vim.fn.system("poetry env info -p"))
+    local path_extended = string.format("%s/bin:%s", poetry_venv, vim.env.PATH)
     vim.env.VIRTUAL_ENV = poetry_venv
+    vim.env.PATH = path_extended
   end
 end
 


### PR DESCRIPTION
I noticed that running nvim via `poetry` fills `PATH` environment variable with path to its virtual environment bin directory. Without that it wasn't finding locally installed packages. Hence, I added the `PATH` extension part.